### PR TITLE
Fix behavior when no config file is present

### DIFF
--- a/zmon_cli/main.py
+++ b/zmon_cli/main.py
@@ -140,10 +140,10 @@ def get_config_data():
         with open(fn) as fd:
             data = yaml.safe_load(fd)
 
-            if "user" not in data or "password" not in data:
-                raise Exception("Config file not found/properly configured: ~/.zmon-cli.yaml with user: and password:")
+    if "user" not in data or "password" not in data:
+        raise Exception("Config file not found/properly configured: ~/.zmon-cli.yaml with user: and password:")
 
-        return data
+    return data
 
 
 def get(url):


### PR DESCRIPTION
When no config file is present, the current version will fail later because there is no config data available. The original intention seems to be to stop processing and warn (reflected in the message).

This change will raise that error when no file is present as well.
