### PR TITLE
Fix place holder character for string.format

### DIFF
--- a/zmon_cli/main.py
+++ b/zmon_cli/main.py
@@ -158,7 +158,7 @@ def get_config_data():
                               allow_unicode=True,
                               encoding='utf-8')
         else:
-            clickclick.warning("No configuration file found at [%s]".format(DEFAULT_CONFIG_FILE))
+            clickclick.warning("No configuration file found at [{}]".format(DEFAULT_CONFIG_FILE))
             data['url'] = click.prompt("ZMon Base URL (e.g. https://zmon2.local/rest/api/v1)")
             data['user'] = click.prompt("ZMon username", default=os.environ['USER'])
 


### PR DESCRIPTION
There is a wrong place holder character used when you have no configuration file in placed, which results in the following output:

```
No configuration file found at [%s]
```
