### PR TITLE
Added support for check definition removal via REST API

### DIFF
--- a/zmon_cli/main.py
+++ b/zmon_cli/main.py
@@ -285,6 +285,7 @@ def delete(url):
     response.raise_for_status()
     return response
 
+
 def delete_body(url, body):
     data = get_config_data()
     response = request(requests.delete, url, data=body,
@@ -295,6 +296,7 @@ def delete_body(url, body):
         return get(url)
     response.raise_for_status()
     return response
+
 
 @cli.group()
 @click.pass_context


### PR DESCRIPTION
Requires https://github.com/zalando/zmon-controller/pull/22 to be merged first.

Removal works with a simple `delete` command similar to the existing `update` one:

```
zmon check-definitions update def.yaml
zmon check-definitions delete def.yaml
```
