### PR TITLE
remove unsupported --output option for entities

### DIFF
--- a/zmon_cli/cmds/entity.py
+++ b/zmon_cli/cmds/entity.py
@@ -19,9 +19,7 @@ from zmon_cli.client import ZmonArgumentError
 
 @cli.group('entities', cls=AliasedGroup, invoke_without_command=True)
 @click.pass_context
-@output_option
-@pretty_json
-def entities(ctx, output, pretty):
+def entities(ctx):
     """Manage entities"""
     if not ctx.invoked_subcommand:
         client = get_client(ctx.obj.config)


### PR DESCRIPTION
zmon entities --output json filter

is not supported by click to set the output to json for the filter sub command

see http://click.pocoo.org/5/commands/#passing-parameters

addresses #55