### PR TITLE
fix opentracing log_kv() arg

### DIFF
--- a/zmon_cli/client.py
+++ b/zmon_cli/client.py
@@ -291,7 +291,7 @@ class Zmon:
         logger.debug('Retrieving entities with query: {} ...'.format(query_str))
 
         current_span = extract_span_from_kwargs(**kwargs)
-        current_span.log_kv({'query', query_str})
+        current_span.log_kv({'query': query_str})
 
         params = {'query': query_str} if query else None
 


### PR DESCRIPTION
must be a dict, not a set, otherwise we'd get something like
```
   File "/usr/local/lib/python3.6/dist-packages/opentracing-1.3.0-py3.6.egg/opentracing/span.py", line 211, in __exit__
     self.finish()
   File "/usr/local/lib/python3.6/dist-packages/basictracer/span.py", line 56, in finish
     self._tracer.record(self)
   File "/usr/local/lib/python3.6/dist-packages/basictracer/tracer.py", line 100, in record
     self.recorder.record_span(span)
   File "/usr/local/lib/python3.6/dist-packages/lightstep/recorder.py", line 184, in record_span
     event = log.key_values.get('event') or ''
 AttributeError: 'set' object has no attribute 'get'
```